### PR TITLE
Fix length calculation for Mac new lines /r/n

### DIFF
--- a/jquery.maxlength.js
+++ b/jquery.maxlength.js
@@ -25,7 +25,8 @@
 					maxLength: parseInt(t.attr("maxlength"), 10),
 					lastLength: null,
 					updateCounter: function(){
-						var length = this.field.val().length,
+						var val = this.field.val().replace(/\r\n/g, '~~').replace(/\n/g, '~~'),
+							length = this.field.val().length,
 							text = this.options.text.replace(/\B%(length|maxlength|left)\b/g, $.proxy(function(match, p){
 								return (p == 'length')? length : (p == 'maxlength')? this.maxLength : (this.maxLength - length);
 							}, this));


### PR DESCRIPTION
The count is incorrect when entering new lines in a textarea on a Mac.  Each new line should count as 2 characters, but jQuery's .length counts /r/n as 1 character.
